### PR TITLE
Remove the legend from the standings using tooltips instead

### DIFF
--- a/standings.html
+++ b/standings.html
@@ -26,27 +26,14 @@
       <caption>Fall Ball 2017</caption>
       <thead>
         <th scope="col">Team</th>
-        <th scope="col">W</th>
-        <th scope="col">L</th>
-        <th scope="col">T</th>
-        <th scope="col">GB</th>
-        <th scope="col">RS</th>
-        <th scope="col">RA</th>
-        <th scope="col">RD</th>
+        <th scope="col"><abbr title="Wins">W</abbr></th>
+        <th scope="col"><abbr title="Losses">L</abbr></th>
+        <th scope="col"><abbr title="Ties">T</abbr></th>
+        <th scope="col"><abbr title="Games Behind">GB</abbr></th>
+        <th scope="col"><abbr title="Runs Scored">RS</abbr></th>
+        <th scope="col"><abbr title="Runs Allowed">RA</abbr></th>
+        <th scope="col"><abbr title="Run Differential">RD</abbr></th>
       </thead>
-      <tfoot>
-        <tr>
-          <th scope="row">Legend</th>
-          <td>Wins</td>
-          <td>Loses</td>
-          <td>Ties</td>
-          <td>Games Behind</td>
-          <td>Runs Scored</td>
-          <td>Runs Allowed</td>
-          <td>Runs Differential</td>
-
-        </tr>
-      </tfoot>
       <tbody>
         <tr>
           <th scope="row" class="world">World Ventures</th>


### PR DESCRIPTION
I propose that the legend on the standings is not in line with most users' expectations, and I think tooltips make sense.

1. The legend was far away from the actual abbreviations, so it feels weird.
2. At first glance, it almost looked like the legend was also one of the teams, so that could be considered confusing.
3. Users on the interwebs are familiar with tooltips and hovering over abbreviations in order to find them.

Overall, it looks cleaner to me. Here's a before and after:

## Before

![before](https://user-images.githubusercontent.com/6025036/34508555-c6f757de-f00e-11e7-956c-2f45ea604611.png)

## After

![after](https://user-images.githubusercontent.com/6025036/34508558-ca66190a-f00e-11e7-9980-535f86fb57f8.png)


What do you think?